### PR TITLE
Update MBWayClient.php

### DIFF
--- a/src/prbdias/mbway/MBWayClient.php
+++ b/src/prbdias/mbway/MBWayClient.php
@@ -135,8 +135,8 @@ class MBWayClient
             'stream_context' => stream_context_create([
                 'ssl' => [
                     'crypto_method' =>  STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
-                    ]
-            ])
+                    ],
+            ]),
 
         ], $options);
 

--- a/src/prbdias/mbway/MBWayClient.php
+++ b/src/prbdias/mbway/MBWayClient.php
@@ -123,18 +123,18 @@ class MBWayClient
         }
 
         $options = array_merge([
-            'local_cert'    => $config->getSSLCert(),
-            'passphrase'    => $config->getSSLPass(),
-            'soap_version'  => SOAP_1_1,
-            'features'      => SOAP_SINGLE_ELEMENT_ARRAYS,
-            'compression'   => SOAP_COMPRESSION_GZIP | SOAP_COMPRESSION_DEFLATE,
-            'keep_alive'    => true,
-            'trace'         => true,
-            'exceptions'    => true,
-            'cache_wsdl'    => WSDL_CACHE_NONE,
+            'local_cert'     => $config->getSSLCert(),
+            'passphrase'     => $config->getSSLPass(),
+            'soap_version'   => SOAP_1_1,
+            'features'       => SOAP_SINGLE_ELEMENT_ARRAYS,
+            'compression'    => SOAP_COMPRESSION_GZIP | SOAP_COMPRESSION_DEFLATE,
+            'keep_alive'     => true,
+            'trace'          => true,
+            'exceptions'     => true,
+            'cache_wsdl'     => WSDL_CACHE_NONE,
             'stream_context' => stream_context_create([
                 'ssl' => [
-                    'crypto_method' =>  STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+                    'crypto_method' => STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
                     ],
             ]),
 

--- a/src/prbdias/mbway/MBWayClient.php
+++ b/src/prbdias/mbway/MBWayClient.php
@@ -132,7 +132,11 @@ class MBWayClient
             'trace'         => true,
             'exceptions'    => true,
             'cache_wsdl'    => WSDL_CACHE_NONE,
-            'ssl_method'    => SOAP_SSL_METHOD_SSLv23,
+            'stream_context' => stream_context_create([
+                'ssl' => [
+                    'crypto_method' =>  STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT,
+                    ]
+            ])
 
         ], $options);
 


### PR DESCRIPTION
Force PHP Native SOAP client to use TLS 1.2 (enforced by SIBS (as it should))